### PR TITLE
ENH: Remove rich as a dependency, update makefile to match new path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,17 @@ install-dev:  ## Install poetry if needed and use it to install calligraphy and 
 	poetry install
 
 lint:  ##        Format and lint calligraphy
-	black calligraphy
-	pylint calligraphy
+	black calligraphy_scripting
+	pylint calligraphy_scripting
 
 test:  ##        Test calligraphy
-	pytest --cov=calligraphy --cov-report=html --cov-fail-under=95 -W ignore::DeprecationWarning
+	pytest --cov=calligraphy_scripting --cov-report=html --cov-fail-under=95 -W ignore::DeprecationWarning
 
 clean:  ##       Remove test and doc artifacts
 	rm -rf .coverage || true
 	rm -rf htmlcov || true
 	rm -rf .pytest_cache || true
-	rm -rf calligraphy/__pycache__ || true
+	rm -rf calligraphy_scripting/__pycache__ || true
 	rm -rf tests/__pycache__ || true
 	rm -rf docs/build || true
 

--- a/calligraphy_scripting/cli.py
+++ b/calligraphy_scripting/cli.py
@@ -4,22 +4,27 @@
 from __future__ import annotations
 import sys
 import os
-from rich.console import Console
 from calligraphy_scripting import parser
 from calligraphy_scripting import transpiler
 from calligraphy_scripting import cleaner
 from calligraphy_scripting import __version__
 
 # Setup global helper variables
-console = Console()
 here = os.path.dirname(os.path.abspath(__file__))
+ANSI_BOLD = "\033[1m"
+ANSI_RED = "\033[31m"
+ANSI_GREEN = "\033[32m"
+ANSI_BLUE = "\033[34m"
+ANSI_RESET = "\033[0m"
 
 
 def version() -> None:
     """Print out the currently installed version of Calligraphy"""
 
     # Output the detected version
-    console.print(f"[bold green]Calligraphy[/bold green]: {__version__}")
+    print(
+        f"{ANSI_GREEN}{ANSI_BOLD}Calligraphy{ANSI_RESET}: {ANSI_BLUE}{__version__}{ANSI_RESET}"
+    )
 
 
 def explain(path: str) -> None:
@@ -44,7 +49,7 @@ def explain(path: str) -> None:
     tokens = parser.parse_lines(lines)
     cleaned = cleaner.clean_tokens(tokens)
     explanation = transpiler.explain(cleaned, imports, functions)
-    console.print(explanation)
+    print(explanation)
 
 
 def intermediate(path: str, args: list) -> None:
@@ -78,7 +83,7 @@ def intermediate(path: str, args: list) -> None:
     header = header.replace('"PROGRAM_ARGS"', str(["calligraphy"] + args))
     code = f"{header}\n\n{code}"
 
-    console.print(code)
+    print(code)
 
 
 def execute(path: str, args: list) -> None:
@@ -120,13 +125,13 @@ def cli() -> None:
     """Handle command line parsing"""
 
     # Help text to be displayed if need be
-    help_text = """[green]usage[/green]: calpgraphy \[option] \[file | -] \[arg]
-    [bold blue]options:[/bold blue]
+    help_text = f"""{ANSI_GREEN}usage{ANSI_RESET}: calpgraphy [option] [file | -] [arg]
+    {ANSI_BOLD}{ANSI_BLUE}options:{ANSI_RESET}
         -h, --help            Show this help message and exit
         -e, --explain         Parse input and show the language breakdown of the source
         -v, --version         Print out the version of Calligraphy and exit
         -i, --intermediate    Print out the compiled Python code and exit
-    [bold blue]arguments:[/bold blue]
+    {ANSI_BOLD}{ANSI_BLUE}arguments:{ANSI_RESET}
         file                  Program read from script file
         -                     Program read from stdin
         arg ...               Arguments passed to the program"""
@@ -134,7 +139,7 @@ def cli() -> None:
 
     # Check if any arguments have been passed
     if len(args) == 0:
-        console.print(help_text)
+        print(help_text)
         sys.exit(1)
 
     # Setup variable defaults
@@ -146,7 +151,7 @@ def cli() -> None:
     # Parse arguments
     for arg in args:
         if arg in ("-h", "--help"):
-            console.print(help_text)
+            print(help_text)
             sys.exit(0)
         if arg in ("-v", "--version"):
             version()
@@ -154,16 +159,16 @@ def cli() -> None:
         if arg in ("-i", "--intermediate"):
             flag_intermediate = True
             if flag_explain:
-                console.print(
-                    "[bold red][ERROR][/bold red] :: Both the `intermediate` and `explain` options cannot be set at the same time."
+                print(
+                    f"{ANSI_RED}{ANSI_BOLD}[ERROR]{ANSI_RESET} :: Both the `intermediate` and `explain` options cannot be set at the same time."
                 )
                 sys.exit(1)
             continue  # pragma: no cover
         if arg in ("-e", "--explain"):
             flag_explain = True
             if flag_intermediate:
-                console.print(
-                    "[bold red][ERROR][/bold red] :: Both the `intermediate` and `explain` options cannot be set at the same time."
+                print(
+                    f"{ANSI_RED}{ANSI_BOLD}[ERROR]{ANSI_RESET} :: Both the `intermediate` and `explain` options cannot be set at the same time."
                 )
                 sys.exit(1)
             continue  # pragma: no cover
@@ -174,8 +179,8 @@ def cli() -> None:
 
     # Make sure a program path was supplied
     if not program_path:
-        console.print(
-            "[bold red][ERROR][/bold red] :: Program input is required, either supply a file path or use `-` for stdin"
+        print(
+            f"{ANSI_RED}{ANSI_BOLD}[ERROR]{ANSI_RESET} :: Program input is required, either supply a file path or use `-` for stdin"
         )
         sys.exit(1)
 

--- a/calligraphy_scripting/transpiler.py
+++ b/calligraphy_scripting/transpiler.py
@@ -7,6 +7,10 @@ from calligraphy_scripting import tokenizer
 
 NO_LEFT_PAD = ["COLON", "RPAREN", "RBRACE", "RBRACKET", "COMMA"]
 NO_RIGHT_PAD = ["LPAREN", "LBRACE", "LBRACKET", "SHELL"]
+ANSI_GREEN = "\033[32m"
+ANSI_BLUE = "\033[34m"
+ANSI_CYAN = "\033[36m"
+ANSI_RESET = "\033[0m"
 
 
 def dump(tokens: list[tokenizer.Token]) -> str:
@@ -181,7 +185,7 @@ def explain(
         if types[idx] == "BASH":
             # Format Bash line
             cmd = dump(line[1:])
-            output += f"[blue]BASH[/blue]   | [blue]{indent}{cmd}[/blue]\n"
+            output += f"{ANSI_BLUE}BASH{ANSI_RESET}   | {ANSI_BLUE}{indent}{cmd}{ANSI_RESET}\n"
         else:
             is_shell = False
             shell_idx = -1
@@ -216,15 +220,13 @@ def explain(
             if is_shell:
                 if rc_idx != -1:
                     # Format mixed line when checking bash RC
-                    output += f"[cyan]MIX[/cyan]    | [green]{indent}{dump(line[1:shell_idx])}[/green] [blue]$?[/blue] [green]{dump(line[rc_idx + 1:])}[/green]\n"
+                    output += f"{ANSI_CYAN}MIX{ANSI_RESET}    | {ANSI_GREEN}{indent}{dump(line[1:shell_idx])}{ANSI_RESET} {ANSI_BLUE}$?{ANSI_RESET} {ANSI_GREEN}{dump(line[rc_idx + 1:])}{ANSI_RESET}\n"
                 else:
                     # Format mixed line when making shell call
-                    output += f"[cyan]MIX[/cyan]    | [green]{indent}{dump(line[1:shell_idx])}[/green] [blue]{dump(line[shell_idx:r_paren_idx+1])}[/blue] [green]{dump(line[r_paren_idx + 1:])}[/green]\n"
+                    output += f"{ANSI_CYAN}MIX{ANSI_RESET}    | {ANSI_GREEN}{indent}{dump(line[1:shell_idx])}{ANSI_RESET} {ANSI_BLUE}{dump(line[shell_idx:r_paren_idx+1])}{ANSI_RESET} {ANSI_GREEN}{dump(line[r_paren_idx + 1:])}{ANSI_RESET}\n"
             else:
                 # Format Python line
-                output += (
-                    f"[green]PYTHON[/green] | [green]{indent}{dump(line[1:])}[/green]\n"
-                )
+                output += f"{ANSI_GREEN}PYTHON{ANSI_RESET} | {ANSI_GREEN}{indent}{dump(line[1:])}{ANSI_RESET}\n"
 
     return output
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -108,20 +108,9 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
-name = "commonmark"
-version = "0.9.1"
-description = "Python parser for the CommonMark Markdown spec"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.extras]
-test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "coverage"
@@ -299,7 +288,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "pygments"
 version = "2.11.2"
 description = "Pygments is a syntax highlighting package written in Python."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
 
@@ -393,22 +382,6 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
-
-[[package]]
-name = "rich"
-version = "11.2.0"
-description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
-category = "main"
-optional = false
-python-versions = ">=3.6.2,<4.0.0"
-
-[package.dependencies]
-colorama = ">=0.4.0,<0.5.0"
-commonmark = ">=0.9.0,<0.10.0"
-pygments = ">=2.6.0,<3.0.0"
-
-[package.extras]
-jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
 
 [[package]]
 name = "snowballstemmer"
@@ -589,7 +562,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c45bf30f0555f101d661ba2b20d874e4ab9cfeb05fe172a9752973eec79044ff"
+content-hash = "1b0f2354afd25626b248856ab5c9913d6958fdd1dce4299e800772169328bf99"
 
 [metadata.files]
 alabaster = [
@@ -652,10 +625,6 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
-]
-commonmark = [
-    {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
-    {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
 ]
 coverage = [
     {file = "coverage-6.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b27d894748475fa858f9597c0ee1d4829f44683f3813633aaf94b19cb5453cf"},
@@ -864,10 +833,6 @@ pytz = [
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
-]
-rich = [
-    {file = "rich-11.2.0-py3-none-any.whl", hash = "sha256:d5f49ad91fb343efcae45a2b2df04a9755e863e50413623ab8c9e74f05aee52b"},
-    {file = "rich-11.2.0.tar.gz", hash = "sha256:1a6266a5738115017bb64a66c59c717e7aa047b3ae49a011ede4abdeffc6536e"},
 ]
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ keywords = ["scripting", "calligraphy"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-rich = "^11.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/tests/data/cli.cli.flag_conflict.out
+++ b/tests/data/cli.cli.flag_conflict.out
@@ -1,2 +1,1 @@
-[ERROR] :: Both the `intermediate` and `explain` options cannot be set at the 
-same time.
+[ERROR] :: Both the `intermediate` and `explain` options cannot be set at the same time.

--- a/tests/data/cli.cli.help.out
+++ b/tests/data/cli.cli.help.out
@@ -1,8 +1,7 @@
 usage: calpgraphy [option] [file | -] [arg]
     options:
         -h, --help            Show this help message and exit
-        -e, --explain         Parse input and show the language breakdown of the
-source
+        -e, --explain         Parse input and show the language breakdown of the source
         -v, --version         Print out the version of Calligraphy and exit
         -i, --intermediate    Print out the compiled Python code and exit
     arguments:

--- a/tests/data/cli.cli.no_program.out
+++ b/tests/data/cli.cli.no_program.out
@@ -1,2 +1,1 @@
-[ERROR] :: Program input is required, either supply a file path or use `-` for 
-stdin
+[ERROR] :: Program input is required, either supply a file path or use `-` for stdin

--- a/tests/data/cli.execute.out
+++ b/tests/data/cli.execute.out
@@ -1,6 +1,5 @@
 Searching in <FILE_PATH>
 Searching for Plagueis
 0
-foobar
 search string found
 bar

--- a/tests/data/cli.explain.out
+++ b/tests/data/cli.explain.out
@@ -1,5 +1,5 @@
 PYTHON | import sys
-PYTHON | import rich as rch
+PYTHON | import os as osmod
 PYTHON | dct = {"a": "b"}
 PYTHON | lst = ["a", "b"]
 PYTHON | tup = ("a", "b")
@@ -10,7 +10,7 @@ PYTHON |     env.SEARCH_TERM = sys.argv [2]
 BASH   |     echo "Searching in env.SEARCH_PATH"
 BASH   |     echo "Searching for env.SEARCH_TERM"
 MIX    |     print ( $? )
-PYTHON |     rch.print ("foobar")
+PYTHON |     osmod.getcwd ()
 MIX    |     if $(cat "env.SEARCH_PATH" | grep -q "env.SEARCH_TERM") == 0:
 PYTHON |         print ("search string found")
 PYTHON |     else:

--- a/tests/data/cli.intermediate.out
+++ b/tests/data/cli.intermediate.out
@@ -10,9 +10,7 @@ import os
 import sys
 from typing import Union
 
-sys.argv = ['calligraphy', 
-'<FILE_PATH>', 
-'Plagueis']
+sys.argv = ['calligraphy', '<FILE_PATH>', 'Plagueis']
 
 
 class Environment:
@@ -41,7 +39,7 @@ class Environment:
             value (str): Value to set the environment variable to
         """
 
-        os.environ = value
+        os.environ[name] = value
 
 
 RC = 0
@@ -51,20 +49,17 @@ env = Environment()
 def shell(
     cmd: str, get_rc: bool = False, get_stdout: bool = False
 ) -> Union[None, str, int]:
-    """Perform a shell call and update the environment with any env variable 
-changes
+    """Perform a shell call and update the environment with any env variable changes
 
     Args:
         cmd (str): The command to run
         get_rc (bool, optional): Should the return code of the call be returned.
             Defaults to False.
-        get_stdout (bool, optional): Should the contents of stdout of the call 
-be
+        get_stdout (bool, optional): Should the contents of stdout of the call be
             returned. Defaults to False.
 
     Returns:
-        Union[None, str, int]: Default None, stdout contents if get_stdout is 
-True and
+        Union[None, str, int]: Default None, stdout contents if get_stdout is True and
             return code if get_rc is True
     """
 
@@ -95,7 +90,7 @@ True and
     for line in envout:
         line = line.strip().split("=")
         if len(line) > 1:
-            os.environ] = line[1]
+            os.environ[line[0]] = line[1]
     if get_stdout:
         return "\n".join(stdout)
     if get_rc:
@@ -105,7 +100,7 @@ True and
 
 
 import sys
-import rich as rch
+import os as osmod
 dct = {"a": "b"}
 lst = ["a", "b"]
 tup = ("a", "b")
@@ -116,9 +111,8 @@ def search ():
     shell ("echo \"Searching in ${SEARCH_PATH}\"")
     shell ("echo \"Searching for ${SEARCH_TERM}\"")
     print (RC)
-    rch.print ("foobar")
-    if shell ("cat \"${SEARCH_PATH}\" | grep -q \"${SEARCH_TERM}\"", get_rc = 
-True) == 0:
+    osmod.getcwd ()
+    if shell ("cat \"${SEARCH_PATH}\" | grep -q \"${SEARCH_TERM}\"", get_rc = True) == 0:
         print ("search string found")
     else:
         print ("Could not find search string")

--- a/tests/data/test.script
+++ b/tests/data/test.script
@@ -1,5 +1,5 @@
 import sys
-import rich as rch
+import os as osmod
 
 # This is a comment
 
@@ -26,7 +26,7 @@ def search():
     echo "Searching in env.SEARCH_PATH"
     echo "Searching for env.SEARCH_TERM"
     print($?)
-    rch.print("foobar")
+    osmod.getcwd()
 
     if $(cat "env.SEARCH_PATH" | grep -q "env.SEARCH_TERM") == 0:
         print('search string found')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import io
 import sys
+import re
 
 class MockIO():
     def __init__(self, stdin=''):
@@ -34,11 +35,15 @@ class MockIO():
 
 here = os.path.dirname(os.path.abspath(__file__))
 
+def escape_ansi(line):
+    ansi_escape = re.compile(r'(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]')
+    return ansi_escape.sub('', line)
+
 def test_version(capfd):
     cli.version()
     out, _ = capfd.readouterr()
 
-    assert out == f"Calligraphy: {__version__}\n"
+    assert escape_ansi(out) == f"Calligraphy: {__version__}\n"
 
 def test_explain(capfd):
     file_path = os.path.join(here, 'data', 'data.txt')
@@ -53,14 +58,14 @@ def test_explain(capfd):
     cli.explain(os.path.join(here, 'data', 'test.script'))
     out, _ = capfd.readouterr()
 
-    assert out == explain_out
+    assert escape_ansi(out) == explain_out
 
     # Test with stdin
     with MockIO(stdin=script) as mock:
         cli.explain('-')
         out = mock.stdout
 
-    assert out == explain_out
+    assert escape_ansi(out) == explain_out
 
 def test_intermediate(capfd):
     file_path = os.path.join(here, 'data', 'data.txt')
@@ -76,14 +81,14 @@ def test_intermediate(capfd):
     cli.intermediate(os.path.join(here, 'data', 'test.script'), [file_path, 'Plagueis'])
     out, _ = capfd.readouterr()
 
-    assert out == intermediate_out
+    assert escape_ansi(out) == intermediate_out
 
     # Test with stdin
     with MockIO(stdin=script) as mock:
         cli.intermediate('-', [file_path, 'Plagueis'])
         out = mock.stdout
 
-    assert out == intermediate_out
+    assert escape_ansi(out) == intermediate_out
     
 
 def test_execute(capfd):
@@ -100,14 +105,14 @@ def test_execute(capfd):
     cli.execute(os.path.join(here, 'data', 'test.script'), [file_path, 'Plagueis'])
     out, _ = capfd.readouterr()
 
-    assert out == execute_out
+    assert escape_ansi(out) == execute_out
 
     # Test with stdin
     with MockIO(stdin=script) as mock:
         cli.execute('-', [file_path, 'Plagueis'])
         out = mock.stdout
 
-    assert out == execute_out
+    assert escape_ansi(out) == execute_out
 
 def test_calligraphy_cli(capfd):
     file_path = os.path.join(here, 'data', 'data.txt')
@@ -146,7 +151,7 @@ def test_calligraphy_cli(capfd):
     assert pytest_wrapped_e.value.code == 1
     out, _ = capfd.readouterr()
 
-    assert out == help_out
+    assert escape_ansi(out) == help_out
 
     # Test help flag
     sys.argv = ['foobar', '-h']
@@ -156,7 +161,7 @@ def test_calligraphy_cli(capfd):
     assert pytest_wrapped_e.value.code == 0
     out, _ = capfd.readouterr()
 
-    assert out == help_out
+    assert escape_ansi(out) == help_out
 
     # Test long help flag
     sys.argv = ['foobar', '--help']
@@ -166,7 +171,7 @@ def test_calligraphy_cli(capfd):
     assert pytest_wrapped_e.value.code == 0
     out, _ = capfd.readouterr()
 
-    assert out == help_out
+    assert escape_ansi(out) == help_out
 
     # Test version flag
     sys.argv = ['foobar', '-v']
@@ -176,7 +181,7 @@ def test_calligraphy_cli(capfd):
     assert pytest_wrapped_e.value.code == 0
     out, _ = capfd.readouterr()
 
-    assert out == version_out
+    assert escape_ansi(out) == version_out
 
     # Test long version flag
     sys.argv = ['foobar', '--version']
@@ -186,7 +191,7 @@ def test_calligraphy_cli(capfd):
     assert pytest_wrapped_e.value.code == 0
     out, _ = capfd.readouterr()
 
-    assert out == version_out
+    assert escape_ansi(out) == version_out
 
     # Test intermediate flag
     sys.argv = ['foobar', '-i', os.path.join(here, 'data', 'test.script'), file_path, 'Plagueis']
@@ -196,7 +201,7 @@ def test_calligraphy_cli(capfd):
     assert pytest_wrapped_e.value.code == 0
     out, _ = capfd.readouterr()
 
-    assert out == intermediate_out
+    assert escape_ansi(out) == intermediate_out
 
     # Test long intermediate flag
     sys.argv = ['foobar', '--intermediate', os.path.join(here, 'data', 'test.script'), file_path, 'Plagueis']
@@ -206,7 +211,7 @@ def test_calligraphy_cli(capfd):
     assert pytest_wrapped_e.value.code == 0
     out, _ = capfd.readouterr()
 
-    assert out == intermediate_out
+    assert escape_ansi(out) == intermediate_out
 
     # Test intermediate flag conflict
     sys.argv = ['foobar', '--intermediate', '-e', os.path.join(here, 'data', 'test.script'), file_path, 'Plagueis']
@@ -216,7 +221,7 @@ def test_calligraphy_cli(capfd):
     assert pytest_wrapped_e.value.code == 1
     out, _ = capfd.readouterr()
 
-    assert out == conflict_out
+    assert escape_ansi(out) == conflict_out
 
     # Test explain flag
     sys.argv = ['foobar', '-e', os.path.join(here, 'data', 'test.script')]
@@ -226,7 +231,7 @@ def test_calligraphy_cli(capfd):
     assert pytest_wrapped_e.value.code == 0
     out, _ = capfd.readouterr()
 
-    assert out == explain_out
+    assert escape_ansi(out) == explain_out
 
     # Test long explain flag
     sys.argv = ['foobar', '--explain', os.path.join(here, 'data', 'test.script')]
@@ -236,7 +241,7 @@ def test_calligraphy_cli(capfd):
     assert pytest_wrapped_e.value.code == 0
     out, _ = capfd.readouterr()
 
-    assert out == explain_out
+    assert escape_ansi(out) == explain_out
 
     # Test explain flag conflict
     sys.argv = ['foobar', '-e', '-i', os.path.join(here, 'data', 'test.script')]
@@ -246,7 +251,7 @@ def test_calligraphy_cli(capfd):
     assert pytest_wrapped_e.value.code == 1
     out, _ = capfd.readouterr()
 
-    assert out == conflict_out
+    assert escape_ansi(out) == conflict_out
 
     # Test not passing a path
     sys.argv = ['foobar', '-e']
@@ -256,12 +261,12 @@ def test_calligraphy_cli(capfd):
     assert pytest_wrapped_e.value.code == 1
     out, _ = capfd.readouterr()
 
-    assert out == no_program_out
+    assert escape_ansi(out) == no_program_out
 
     # Test running a script
     sys.argv = ['foobar', os.path.join(here, 'data', 'test.script'), file_path, 'Plagueis']
     cli.cli()
     out, _ = capfd.readouterr()
 
-    assert out == execute_out
+    assert escape_ansi(out) == execute_out
 


### PR DESCRIPTION
# Changes

- Implemented direct ANSI codes instead of using rich for terminal formatting to get around issue with rich eating text between brackets
- Updated Makefile to conform to new directory name of `caligraphy_scripting`