### PR TITLE
[CAL-10] Fix "Escaped quotes in bash lines break execution"

### DIFF
--- a/calligraphy_scripting/transpiler.py
+++ b/calligraphy_scripting/transpiler.py
@@ -38,9 +38,11 @@ def dump(tokens: list[tokenizer.Token], should_escape: bool = True) -> str:
             no_right_pad = True
             continue
         if tok.t_type == "STRING":
+            # Add quotes around strings
             if should_escape:
-                # Add quotes around strings
-                string = tok.t_value.replace('"', '\\"')
+                # Escape quote marks in strings
+                string = tok.t_value.replace('\\"', '\\\\"')
+                string = string.replace('"', '\\"')
             else:
                 string = tok.t_value
             text = f'"{string}"'

--- a/tests/data/cli.execute.out
+++ b/tests/data/cli.execute.out
@@ -1,4 +1,5 @@
 success
+This is a "test"
 Searching in <FILE_PATH>
 Searching for Plagueis
 0

--- a/tests/data/cli.explain.out
+++ b/tests/data/cli.explain.out
@@ -7,6 +7,7 @@ PYTHON | x = 5 + 4
 PYTHON | env.ENV_NAME = "foobar"
 MIX    | if $([[ "env.ENV_NAME" =~ ^([a-zA-Z0-9]|-)*$ ]]) == 0:
 PYTHON |     print ("success")
+BASH   | echo "This is a \"test\""
 PYTHON | def search ():
 PYTHON |     env.SEARCH_PATH = sys.argv [1]
 PYTHON |     env.SEARCH_TERM = sys.argv [2]

--- a/tests/data/cli.intermediate.out
+++ b/tests/data/cli.intermediate.out
@@ -108,6 +108,7 @@ x = 5 + 4
 env.ENV_NAME = "foobar"
 if shell ("[[ \"${ENV_NAME}\" =~ ^([a-zA-Z0-9]|-)*$ ]]", get_rc = True) == 0:
     print ("success")
+shell ("echo \"This is a \\\"test\\\"\"")
 def search ():
     env.SEARCH_PATH = sys.argv [1]
     env.SEARCH_TERM = sys.argv [2]

--- a/tests/data/test.script
+++ b/tests/data/test.script
@@ -24,6 +24,8 @@ env.ENV_NAME = 'foobar'
 if $([[ "env.ENV_NAME" =~ ^([a-zA-Z0-9]|-)*$ ]]) == 0:
     print("success")
 
+echo "This is a \"test\""
+
 def search():
     env.SEARCH_PATH = sys.argv[1]
     env.SEARCH_TERM = sys.argv[2]


### PR DESCRIPTION
# Changes
- Escape any found `\"` with `\\"` before quote escaping so that they become `\\\"` and are valid