### PR TITLE
MAINT: Fix commands which do not end with a newline resulting in env …

### DIFF
--- a/calligraphy_scripting/data/header.py
+++ b/calligraphy_scripting/data/header.py
@@ -65,7 +65,7 @@ def shell(
 
     env_marker = "~~~~START_ENVIRONMENT_HERE~~~~"
     global RC
-    cmd = f"bash -c '{cmd}' && echo {env_marker} && printenv"
+    cmd = f"bash -c '{cmd}' && echo \"\n\" && echo {env_marker} && printenv"
     stdout = []
     envout = []
 


### PR DESCRIPTION
…being printed out along with them

# Changes
- Added a newline print after Bash command execution to ensure that we can properly parse the output