### PR TITLE
[CAL-3] Enable sourcing of other Calligraphy scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 /docs/build
 /dist
 /coverage.xml
+/tests/data/.test3.py

--- a/calligraphy_scripting/cli.py
+++ b/calligraphy_scripting/cli.py
@@ -78,6 +78,7 @@ def intermediate(path: str, args: list) -> None:
 
     # Process the contents
     contents, inline_indices = parser.handle_line_breaks(contents)
+    contents = parser.handle_sourcing(contents)
     lines, langs = parser.determine_language(contents)
     transpiled = transpiler.transpile(lines, langs, inline_indices)
 
@@ -108,6 +109,7 @@ def execute(path: str, args: list) -> None:
 
     # Process the contents
     contents, inline_indices = parser.handle_line_breaks(contents)
+    contents = parser.handle_sourcing(contents)
     lines, langs = parser.determine_language(contents)
     transpiled = transpiler.transpile(lines, langs, inline_indices)
 

--- a/calligraphy_scripting/data/header.py
+++ b/calligraphy_scripting/data/header.py
@@ -9,6 +9,7 @@ import subprocess
 import os
 import sys
 from typing import Union
+import importlib.util
 
 sys.argv = "PROGRAM_ARGS"
 
@@ -40,6 +41,26 @@ class Environment:
         """
 
         os.environ[name] = value
+
+
+def source_import(calligraphy_path, module_name):
+    if not calligraphy_path.endswith(".script"):
+        raise ImportError(
+            "Calligraphy only support sourcing other scripts that end with the '.script' extension"
+        )
+    if not os.path.exists(calligraphy_path):
+        raise FileNotFoundError(
+            f"Sourced script of '{calligraphy_path}' does not exist"
+        )
+
+    directory, script = os.path.split(calligraphy_path)
+    python_path = os.path.join(directory, f".{script[:-7]}.py")
+
+    spec = importlib.util.spec_from_file_location(module_name, python_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 RC = 0

--- a/calligraphy_scripting/transpiler.py
+++ b/calligraphy_scripting/transpiler.py
@@ -8,6 +8,7 @@ import base64
 ANSI_GREEN = "\033[32m"
 ANSI_BLUE = "\033[34m"
 ANSI_CYAN = "\033[36m"
+ANSI_MAGENTA = "\033[35m"
 ANSI_GREY = "\033[90m"
 ANSI_RESET = "\033[0m"
 CMD_SUFFIX = " && echo '\n' && echo ~~~~START_ENVIRONMENT_HERE~~~~ && printenv && echo ~~~~START_CWD_HERE~~~~ && pwd"
@@ -31,19 +32,19 @@ def explain(lines: list[str], langs: list[str], inline_indices: list[str]) -> st
     for idx, line in enumerate(lines):
         if langs[idx] == "COMMENT":
             output += (
-                f"{ANSI_GREY}COMMENT{ANSI_RESET} | {ANSI_GREY}{line}{ANSI_RESET}\n"
+                f"{ANSI_GREY}COMMENT{ANSI_RESET}     | {ANSI_GREY}{line}{ANSI_RESET}\n"
             )
         elif langs[idx] == "BASH":
             output += (
-                f"{ANSI_BLUE}BASH{ANSI_RESET}    | {ANSI_BLUE}{line}{ANSI_RESET}\n"
+                f"{ANSI_BLUE}BASH{ANSI_RESET}        | {ANSI_BLUE}{line}{ANSI_RESET}\n"
             )
         elif langs[idx] == "PYTHON":
-            output += (
-                f"{ANSI_GREEN}PYTHON{ANSI_RESET}  | {ANSI_GREEN}{line}{ANSI_RESET}\n"
-            )
+            output += f"{ANSI_GREEN}PYTHON{ANSI_RESET}      | {ANSI_GREEN}{line}{ANSI_RESET}\n"
+        elif langs[idx] == "CALLIGRAPHY":
+            output += f"{ANSI_MAGENTA}CALLIGRAPHY{ANSI_RESET} | {ANSI_MAGENTA}{line}{ANSI_RESET}\n"
         else:
             inline_idx = [i for i in inline_indices if i[0] == idx][0]
-            output += f"{ANSI_CYAN}MIX{ANSI_RESET}     | {ANSI_GREEN}{line[:inline_idx[1]]}{ANSI_RESET}{ANSI_BLUE}{line[inline_idx[1]:inline_idx[2]+1]}{ANSI_RESET}{ANSI_GREEN}{line[inline_idx[2] + 1:]}{ANSI_RESET}\n"
+            output += f"{ANSI_CYAN}MIX{ANSI_RESET}         | {ANSI_GREEN}{line[:inline_idx[1]]}{ANSI_RESET}{ANSI_BLUE}{line[inline_idx[1]:inline_idx[2]+1]}{ANSI_RESET}{ANSI_GREEN}{line[inline_idx[2] + 1:]}{ANSI_RESET}\n"
 
     output = output.replace("<CALLIGRAPHY_NEWLINE>", "\n")
     return output

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1,6 +1,136 @@
 Reference
 =========
 
-.. note::
+File Format
+-----------
 
-   This page is still being developed, check back later for more content!
+Calligraphy uses the ``.script`` file extension. While this doesn't *actually* matter 
+for single-file scripts, it is enforced when sourcing other Calligraphy scripts into a 
+larger program.
+
+Language Detection
+------------------
+
+Calligraphy language detection operates under the following rules:
+
+1. If a line starts with a Python keyword then it's a Python (or mixed) line.
+
+   This gives rise to the need for the inline-bash marker, but ultimately keeps the 
+   syntax and parsing simpler than it otherwise would need to be.
+
+2. If a line follows the pattern ``<something> = <something>`` then it's a Python (or mixed) line.
+   
+   By disallowing setting environment variables from within Bash we can use assignment 
+   detection as a rule for if a line is Python or not.
+
+3. If a line starts with ``<already found variable or import name>.`` then it's a Python (or mixed) line.
+   
+   This is to handle things like having imported ``matplotlib.pyplot as plt`` and then 
+   having a line that is ``plt.show()``.
+
+4. If a line starts with ``source ...`` then it's a Calligraphy (to be converted to Python).
+
+   This is a hard rule coming from the decided upon syntax for Calligraphy imports.
+
+5. If a line contains ``$(...)`` or ``?(...)`` then it's a mixed line with that section being Bash.
+
+   This works in conjunction with the first rule in the list. In addition, other markers 
+   of ``<some symbol>(...)`` will be added in the future to expand the functionality.
+
+6. Any lines that don't have a language assigned are then considered to be Bash.
+
+Inline Bash
+-----------
+
+Inline Bash commands take two forms:
+
+$(...)
+~~~~~~
+
+This executes the bash while printing/capturing stdout and returning it. If this is used
+within an if statement then the captured stdout will not be returned and instead the
+command's return code will be returned.
+
+?(...)
+~~~~~~
+
+This operates the exact same way as ``$(...)`` except it does **NOT** print to stdout.
+
+Program Arguments
+-----------------
+
+To make things more readable and more inline with teh purpose of being scripts run from 
+a terminal for automation/devops purposes, Calligraphy uses the same syntax as Bash when
+accessing the system arguments. For example, given the arguments:
+
+- foo
+- bar
+- baz
+
+``$1`` will give you ``foo``.  Please note that while in bash function arguments are 
+also accessed this way, that is not the case in Calligraphy and they are instead 
+accessed by their name in the normal Pythonic manner.
+
+Environment Variables
+---------------------
+
+To keep a consistent method of accessing/setting environment variables in Calligraphy, 
+they are only set from Python lines via the ``env`` variable. For example,
+
+.. code-block:: python
+   
+   env.FOOBAR = "baz"
+
+will set the environment variable ``FOOBAR`` to ``baz``. Any environment variables set 
+from Python will have the same value if accessed from Bash. In addition, any environment
+variables set as a consequence to running a Bash command will have their new values 
+reflected when accessed from Python. You can access environment variables via the same 
+``env`` variable in the following manner:
+
+.. code-block:: python
+
+   print(env.FOOBAR)
+
+Bash Return Codes
+-----------------
+
+While Python gives us the ability to use ``try`` and ``except`` blocks to handle errors,
+Bash forces us to make do with return codes. In the future the return codes from bash 
+will be wrapped into exception classes within Calligraphy, but for the time being you 
+can access the return code of the last run Bash command via ``$?``. For example:
+
+.. code-block::
+
+   echo "this is a test" | false
+
+   if $? != 0:
+      print('The previous command failed!')
+
+will produce
+
+.. code-block:: console
+
+   The previous command failed!
+
+Sourcing Other Scripts
+----------------------
+
+When linking multiple Calligraphy scripts in order to produce a larger program, you'll
+use the ``source`` command. It can be used in two ways:
+
+.. code-block::
+
+   source /path/to/foo.script
+   source /path/to/bar.script as baz
+
+This has the same effect as if you had imported the transpiled output of ``foo.script`` 
+under the module name ``foo`` or had imported the transpiled output of ``bar.script`` 
+under the module name ``baz``.
+
+Recommended IDE Settings
+------------------------
+
+When working in an IDE with Calligraphy, it is recommended that you configure the 
+``.script`` extension to be subject to Python syntax highlighting. In addition, add
+``# type: ignore`` to the top of your file so that built-in linters don't complain about
+the Bash present in the file.

--- a/docs/source/writing.rst
+++ b/docs/source/writing.rst
@@ -64,7 +64,8 @@ there are a few rules that must be followed:
    as being Bash code and will execute it as such. For example, if we took the following
    code snippet:
 
-   .. code-block: Python
+   .. code-block::
+
       cat test.txt | grep "foobar" > matches.txt
       with open('matches.txt') as f:
          matches = f.read().split('\n')
@@ -74,14 +75,16 @@ there are a few rules that must be followed:
    Calligraphy interpreter to show how Calligraphy has parsed your script/interpreted the
    languages.
 
-5. ``$(...)`` denotes inline Bash
+5. ``$(...)`` and ``?(...)`` denote inline Bash
 
    A decent chunk of the time it isn't super useful to pipe output to files and read them
    in so that you can access them from the Python side of things. To help with this issue
    you can wrap Bash code that's on a Python line with ``$(...)`` to tell Calligraphy that 
    it's a shell command. Calligraphy will return the contents of stdout when calls are 
    wrapped in such a manner except for when it's contained within an if statement. In that 
-   scenario Calligraphy will return the return code of the shell call performed.
+   scenario Calligraphy will return the return code of the shell call performed. In 
+   addition, wrapping the Bash code with ``?(...)`` will act in the same manner as 
+   ``$(...)`` except it won't print to stdout.
 
 6. ``$?`` will give you the return code of the last shell command to be run
 
@@ -100,3 +103,10 @@ there are a few rules that must be followed:
    determination. Therefore, the Bash pattern of ``NAME="value"`` is not permitted in the 
    Calligraphy language. If you need to set and environment variable to the output of a
    shell command you can use ``env.NAME = $(...)``
+
+9. Other Calligraphy scripts can be imported via ``source path/to/other/module.script`` 
+
+   For example, if you used ``source path/to/foo.script`` you when then be able to use
+   ``foo.bar`` to access the variable ``bar`` within the ``foo`` module. You can also 
+   use ``source path/to/foo.script as baz`` to rename the import, meaning you would
+   instead use ``baz.bar`` instead of ``foo.bar``

--- a/test.script
+++ b/test.script
@@ -1,0 +1,6 @@
+# type: ignore
+
+echo "this is a test" | false
+
+if $? != 0:
+    print('The previous command failed!')

--- a/tests/data/cli.explain.out
+++ b/tests/data/cli.explain.out
@@ -1,32 +1,32 @@
-PYTHON  | import sys
-PYTHON  | import os as osmod
-COMMENT | # This is a comment
-PYTHON  | dct = {
+PYTHON      | import sys
+PYTHON      | import os as osmod
+COMMENT     | # This is a comment
+PYTHON      | dct = {
     "a": "b"
 }
-PYTHON  | lst = [
+PYTHON      | lst = [
     "a",
     "b"
 ]
-PYTHON  | tup = (
+PYTHON      | tup = (
     "a",
     "b"
 )
-PYTHON  | env.ENV_NAME = 'foobar'
-MIX     | if $([[ "env.ENV_NAME" =~ ^([a-zA-Z0-9]|-)*$ ]]) == 0:
-PYTHON  |     print("success")
-BASH    | echo "This is a \"test\""
-PYTHON  | def search():
-PYTHON  |     env.SEARCH_PATH = sys.argv[1]
-PYTHON  |     env.SEARCH_TERM = sys.argv[2]
-BASH    |     echo "Searching in env.SEARCH_PATH"
-BASH    |     echo "Searching for env.SEARCH_TERM"
-PYTHON  |     print($?)
-PYTHON  |     osmod.getcwd()
-MIX     |     if $(cat "env.SEARCH_PATH" | grep -q "env.SEARCH_TERM") == 0:
-PYTHON  |         print('search string found')
-PYTHON  |     else:
-PYTHON  |         print('Could not find search string')
-MIX     |     env.FOO = $(echo "bar")
-PYTHON  | search()
+PYTHON      | env.ENV_NAME = 'foobar'
+MIX         | if $([[ "env.ENV_NAME" =~ ^([a-zA-Z0-9]|-)*$ ]]) == 0:
+PYTHON      |     print("success")
+BASH        | echo "This is a \"test\""
+PYTHON      | def search():
+PYTHON      |     env.SEARCH_PATH = sys.argv[1]
+PYTHON      |     env.SEARCH_TERM = sys.argv[2]
+BASH        |     echo "Searching in env.SEARCH_PATH"
+BASH        |     echo "Searching for env.SEARCH_TERM"
+PYTHON      |     print($?)
+PYTHON      |     osmod.getcwd()
+MIX         |     if $(cat "env.SEARCH_PATH" | grep -q "env.SEARCH_TERM") == 0:
+PYTHON      |         print('search string found')
+PYTHON      |     else:
+PYTHON      |         print('Could not find search string')
+MIX         |     env.FOO = $(echo "bar")
+PYTHON      | search()
 

--- a/tests/data/cli.explain.stdin.out
+++ b/tests/data/cli.explain.stdin.out
@@ -1,40 +1,40 @@
-PYTHON  | import sys
-PYTHON  | import os as osmod
-COMMENT | # This is a comment
-PYTHON  | dct = {
+PYTHON      | import sys
+PYTHON      | import os as osmod
+COMMENT     | # This is a comment
+PYTHON      | dct = {
 
     "a": "b"
 
 }
-PYTHON  | lst = [
+PYTHON      | lst = [
 
     "a",
 
     "b"
 
 ]
-PYTHON  | tup = (
+PYTHON      | tup = (
 
     "a",
 
     "b"
 
 )
-PYTHON  | env.ENV_NAME = 'foobar'
-MIX     | if $([[ "env.ENV_NAME" =~ ^([a-zA-Z0-9]|-)*$ ]]) == 0:
-PYTHON  |     print("success")
-BASH    | echo "This is a \"test\""
-PYTHON  | def search():
-PYTHON  |     env.SEARCH_PATH = sys.argv[1]
-PYTHON  |     env.SEARCH_TERM = sys.argv[2]
-BASH    |     echo "Searching in env.SEARCH_PATH"
-BASH    |     echo "Searching for env.SEARCH_TERM"
-PYTHON  |     print($?)
-PYTHON  |     osmod.getcwd()
-MIX     |     if $(cat "env.SEARCH_PATH" | grep -q "env.SEARCH_TERM") == 0:
-PYTHON  |         print('search string found')
-PYTHON  |     else:
-PYTHON  |         print('Could not find search string')
-MIX     |     env.FOO = $(echo "bar")
-PYTHON  | search()
+PYTHON      | env.ENV_NAME = 'foobar'
+MIX         | if $([[ "env.ENV_NAME" =~ ^([a-zA-Z0-9]|-)*$ ]]) == 0:
+PYTHON      |     print("success")
+BASH        | echo "This is a \"test\""
+PYTHON      | def search():
+PYTHON      |     env.SEARCH_PATH = sys.argv[1]
+PYTHON      |     env.SEARCH_TERM = sys.argv[2]
+BASH        |     echo "Searching in env.SEARCH_PATH"
+BASH        |     echo "Searching for env.SEARCH_TERM"
+PYTHON      |     print($?)
+PYTHON      |     osmod.getcwd()
+MIX         |     if $(cat "env.SEARCH_PATH" | grep -q "env.SEARCH_TERM") == 0:
+PYTHON      |         print('search string found')
+PYTHON      |     else:
+PYTHON      |         print('Could not find search string')
+MIX         |     env.FOO = $(echo "bar")
+PYTHON      | search()
 

--- a/tests/data/cli.explain2.out
+++ b/tests/data/cli.explain2.out
@@ -1,0 +1,10 @@
+COMMENT     | # type: ignore
+COMMENT     | """This is a 
+multiline comment"""
+PYTHON      | x = 4 + \
+    5
+CALLIGRAPHY | source tests/data/test3.script as foo
+PYTHON      | if $1 == "-h":
+PYTHON      |     print(foo.HELP)
+MIX         | bar = ?(echo "bar")
+

--- a/tests/data/cli.help_flag.out
+++ b/tests/data/cli.help_flag.out
@@ -1,0 +1,1 @@
+HELP TEXT

--- a/tests/data/cli.intermediate.out
+++ b/tests/data/cli.intermediate.out
@@ -9,6 +9,7 @@ import subprocess
 import os
 import sys
 from typing import Union
+import importlib.util
 
 sys.argv = ['calligraphy', '<FILE_PATH>', 'Plagueis']
 
@@ -40,6 +41,26 @@ class Environment:
         """
 
         os.environ[name] = value
+
+
+def source_import(calligraphy_path, module_name):
+    if not calligraphy_path.endswith(".script"):
+        raise ImportError(
+            "Calligraphy only support sourcing other scripts that end with the '.script' extension"
+        )
+    if not os.path.exists(calligraphy_path):
+        raise FileNotFoundError(
+            f"Sourced script of '{calligraphy_path}' does not exist"
+        )
+
+    directory, script = os.path.split(calligraphy_path)
+    python_path = os.path.join(directory, f".{script[:-7]}.py")
+
+    spec = importlib.util.spec_from_file_location(module_name, python_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 RC = 0

--- a/tests/data/cli.intermediate.stdin.out
+++ b/tests/data/cli.intermediate.stdin.out
@@ -9,6 +9,7 @@ import subprocess
 import os
 import sys
 from typing import Union
+import importlib.util
 
 sys.argv = ['calligraphy', '<FILE_PATH>', 'Plagueis']
 
@@ -40,6 +41,26 @@ class Environment:
         """
 
         os.environ[name] = value
+
+
+def source_import(calligraphy_path, module_name):
+    if not calligraphy_path.endswith(".script"):
+        raise ImportError(
+            "Calligraphy only support sourcing other scripts that end with the '.script' extension"
+        )
+    if not os.path.exists(calligraphy_path):
+        raise FileNotFoundError(
+            f"Sourced script of '{calligraphy_path}' does not exist"
+        )
+
+    directory, script = os.path.split(calligraphy_path)
+    python_path = os.path.join(directory, f".{script[:-7]}.py")
+
+    spec = importlib.util.spec_from_file_location(module_name, python_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 RC = 0

--- a/tests/data/test2.script
+++ b/tests/data/test2.script
@@ -1,0 +1,14 @@
+# type: ignore
+
+"""This is a 
+multiline comment"""
+
+x = 4 + \
+    5
+
+source tests/data/test3.script as foo
+
+if $1 == "-h":
+    print(foo.HELP)
+
+bar = ?(echo "bar")

--- a/tests/data/test3.script
+++ b/tests/data/test3.script
@@ -1,0 +1,3 @@
+# type: ignore
+
+HELP = "HELP TEXT"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -282,3 +282,26 @@ def test_calligraphy_cli(capfd):
 
     assert escape_ansi(out) == execute_out
 
+def test_help_flag(capfd):
+    with open(os.path.join(here, 'data', 'cli.help_flag.out')) as out_file:
+        help_flag_out = out_file.read()
+    
+    with open(os.path.join(here, 'data', 'cli.explain2.out')) as out_file:
+        explain_out = out_file.read()
+
+    # Test help flag passing
+    sys.argv = ['foobar', os.path.join(here, 'data', 'test2.script'), '-h']
+    cli.cli()
+    out, _ = capfd.readouterr()
+
+    assert escape_ansi(out) == help_flag_out
+
+    # Test explain output with source
+    sys.argv = ['foobar', os.path.join(here, 'data', 'test2.script'), '-e']
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        cli.cli()
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 0
+    out, _ = capfd.readouterr()
+
+    assert escape_ansi(out) == explain_out


### PR DESCRIPTION
# Changes
- Enabled the use of the `source` directive to import other Calligraphy scripts into larger programs