### PR TITLE
[CAL-24] Resolve language parsing issues

### DIFF
--- a/calligraphy_scripting/__init__.py
+++ b/calligraphy_scripting/__init__.py
@@ -2,4 +2,4 @@
 
 from calligraphy_scripting import runner
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"

--- a/calligraphy_scripting/transpiler.py
+++ b/calligraphy_scripting/transpiler.py
@@ -100,4 +100,5 @@ def transpile(lines: list[str], langs: list[str], inline_indices: list[str]) -> 
                 output += f'{line[:inline_idx[1]]}shell("{base64_cmd}", get_stdout=True, silent={raw[0]=="?"}, format_dict={{**globals(), **locals()}}){line[inline_idx[2]:]}\n'
 
     output = output.replace("<CALLIGRAPHY_NEWLINE>", "\n")
+
     return output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calligraphy-scripting"
-version = "1.1.3"
+version = "1.1.4"
 description = "A hybrid language for a modern approach to shell scripting"
 authors = ["John Carter <jfcarter2358@gmail.com>"]
 license = "MIT"

--- a/tests/data/cli.version.out
+++ b/tests/data/cli.version.out
@@ -1,1 +1,1 @@
-Calligraphy: 1.1.3
+Calligraphy: 1.1.4


### PR DESCRIPTION
- [CAL-24] Fixed language parsing
    - Fixed issues where Bash commands starting with Python keywords are identified as Python lines
        - E.g. `openssl ...` starts with `open` and so was identified as a Python line
    - Fixed issue where keyword functions were not correctly identified
        - E.g. `print(...)` when split by spaces does not have the first part equal to `print` and so was identified as a Bash line